### PR TITLE
Fix: remove raw footage VOD guidelines (pending Russian fixes)

### DIFF
--- a/en-US/000_index/200_changelog.md
+++ b/en-US/000_index/200_changelog.md
@@ -4,11 +4,7 @@
 
 This archives the various changes the list team has made to the rules and guidelines of the Demon List. Our main notification system for new changes is in our [Discord server](https://discord.gg/M7bDDQf), so if you are not a member there, it's a good idea to check this section occasionally for new updates.
 
-Changes listed here are ordered from most recent to least recent. **Current version: v2.5**
-
-## Changes from v2.4 to v2.5 (5/16/2025){id=changelog-5162025}
-
-- Stream VODs are no longer a valid form of raw footage.
+Changes listed here are ordered from most recent to least recent. **Current version: v2.4**
 
 ## Changes from v2.3 to v2.4 (10/16/2024){id=changelog-10162024}
 

--- a/en-US/250_Raw_Footage/100_requirements.md
+++ b/en-US/250_Raw_Footage/100_requirements.md
@@ -20,8 +20,6 @@ Invalid raw footage links **will** result in a rejected record. However, players
 
 [(Video Tutorial)](https://youtu.be/3LeRPX9bETw?feature=shared)
 
-Stream VODs are **not** a valid form of raw footage, but they can be a great form of _supplementary_ evidence that your completion is legitimate. If you are experiencing lag while streaming and recording simultaneously, try following [this guide](https://docs.google.com/document/d/1ulAtWShfklBaswCuaRdQwWpHGkk9V-dKi6-2veaaS8M/) to optimize your recording software.
-
 ## File Size{id=filesize}
 
 Raw footage of 5 to 15 minutes at moderately high quality is recommended; however, there is **no maximum or minimum file size or video length** for raw footage to be considered. Recording your entire game session is not required!


### PR DESCRIPTION
Seems like VODs as raw footage aren't allowed anymore ([Discord message](https://discord.com/channels/395654171422097420/395692399919366147/1373005359110950994)).

"After May 22nd 2025 00:00 EST, livestreams will no longer be accepted as valid form of raw footage for record submissions."
"From that date forward, only unedited recordings captured through recording software (e.g., OBS, Shadowplay / NVIDIA APP, AMD Relive), and liveplays will be accepted on Pointercrate."

There are a few things I changed that should probably be matched on the Russian translations, although I've already removed the "Livestreams" section from it.

[Pointercrate PR](https://github.com/stadust/pointercrate/pull/290)

I incremented the version to v2.5, but I wasn't sure if that should be done for singular changes like this? I also wasn't sure if removing [the "Livestreams" header with the ID](https://pointercrate.com/guidelines/rawfootage#livestreams) was the right move, or if it's better to just change the text there. I can change those things if needed :)